### PR TITLE
Refactor card scan testbed UI

### DIFF
--- a/services/frontend/cardscantest/src/App.css
+++ b/services/frontend/cardscantest/src/App.css
@@ -6,6 +6,14 @@ body, html, #root {
   font-family: sans-serif;
 }
 
+/* Top bar */
+.top-bar {
+  padding: 10px;
+  border-bottom: 1px solid #ccc;
+  display: flex;
+  gap: 10px;
+}
+
 /* Main layout container */
 .layout {
   display: flex;

--- a/services/frontend/cardscantest/src/App.jsx
+++ b/services/frontend/cardscantest/src/App.jsx
@@ -1,12 +1,20 @@
 import { useState } from 'react';
 import './App.css';
+import TopBar from './components/TopBar';
+import CardForm from './components/CardForm';
+import MatchedCard from './components/MatchedCard';
+import SQLPreview from './components/SQLPreview';
 
 function App() {
   const [formData, setFormData] = useState({
     name: '',
     set_num: '',
     hp: '',
+    types: '',
+    attacks: '',
   });
+
+  const [matchedCard, setMatchedCard] = useState(null);
 
   const handleChange = (e) => {
     setFormData({
@@ -15,43 +23,33 @@ function App() {
     });
   };
 
+  const handleMatch = () => {
+    // placeholder for now
+    setMatchedCard({
+      name: 'Pikachu V',
+      set_num: '045/196',
+      rarity: 'Ultra Rare',
+      evolves_from: 'Pichu',
+    });
+  };
+
   const generateSQL = () => {
     let conditions = [];
     if (formData.name) conditions.push(`name ILIKE '%${formData.name}%'`);
     if (formData.set_num) conditions.push(`set_num = '${formData.set_num}'`);
     if (formData.hp) conditions.push(`hp = '${formData.hp}'`);
+    if (formData.types) conditions.push(`types @> '{${formData.types}}'`);
+    if (formData.attacks) conditions.push(`attacks @> '{${formData.attacks}}'`);
     return `SELECT * FROM cards${conditions.length ? ' WHERE ' + conditions.join(' AND ') : ''};`;
   };
 
   return (
     <>
-      {/* Top Bar */}
-      <div style={{ padding: '10px', borderBottom: '1px solid #ccc', display: 'flex', gap: '10px' }}>
-        <button disabled>📸 Capture</button>
-        <button disabled>📁 Upload</button>
-        <button>🔁 Match Now</button>
-      </div>
-
+      <TopBar onMatch={handleMatch} />
       <div className="layout">
-        {/* Left: Form */}
-        <div className="panel left">
-          <h2>Card Form</h2>
-          <input name="name" placeholder="Name" value={formData.name} onChange={handleChange} />
-          <input name="set_num" placeholder="Set #" value={formData.set_num} onChange={handleChange} />
-          <input name="hp" placeholder="HP" value={formData.hp} onChange={handleChange} />
-        </div>
-
-        {/* Middle: Matched Card Info (Placeholder) */}
-        <div className="panel center">
-          <h2>Matched Card Info</h2>
-          <p>This will show matched data from backend.</p>
-        </div>
-
-        {/* Right: SQL Preview */}
-        <div className="panel right">
-          <h2>SQL Preview</h2>
-          <pre>{generateSQL()}</pre>
-        </div>
+        <CardForm formData={formData} onChange={handleChange} />
+        <MatchedCard card={matchedCard} />
+        <SQLPreview query={generateSQL()} />
       </div>
     </>
   );

--- a/services/frontend/cardscantest/src/components/CardForm.jsx
+++ b/services/frontend/cardscantest/src/components/CardForm.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function CardForm({ formData, onChange }) {
+  return (
+    <div className="panel left">
+      <h2>Card Detail Form</h2>
+      <input name="name" placeholder="Name" value={formData.name} onChange={onChange} />
+      <input name="set_num" placeholder="Set #" value={formData.set_num} onChange={onChange} />
+      <input name="hp" placeholder="HP" value={formData.hp} onChange={onChange} />
+      <input name="types" placeholder="Type(s)" value={formData.types} onChange={onChange} />
+      <input name="attacks" placeholder="Attacks" value={formData.attacks} onChange={onChange} />
+    </div>
+  );
+}

--- a/services/frontend/cardscantest/src/components/MatchedCard.jsx
+++ b/services/frontend/cardscantest/src/components/MatchedCard.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export default function MatchedCard({ card }) {
+  if (!card) {
+    return (
+      <div className="panel center">
+        <h2>Matched Card Info</h2>
+        <p>No card matched yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="panel center">
+      <h2>Matched Card Info</h2>
+      <p><strong>Name:</strong> {card.name}</p>
+      <p><strong>Set #:</strong> {card.set_num}</p>
+      <p><strong>Rarity:</strong> {card.rarity}</p>
+      <p><strong>Evolves From:</strong> {card.evolves_from}</p>
+    </div>
+  );
+}

--- a/services/frontend/cardscantest/src/components/SQLPreview.jsx
+++ b/services/frontend/cardscantest/src/components/SQLPreview.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function SQLPreview({ query }) {
+  return (
+    <div className="panel right">
+      <h2>SQL Preview</h2>
+      <pre>{query}</pre>
+    </div>
+  );
+}

--- a/services/frontend/cardscantest/src/components/TopBar.jsx
+++ b/services/frontend/cardscantest/src/components/TopBar.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function TopBar({ onMatch }) {
+  return (
+    <div className="top-bar">
+      <button disabled>📸 Capture Card</button>
+      <button disabled>📁 Upload Image</button>
+      <button onClick={onMatch}>🔁 Match Now</button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- refactor cardscantest testbed into modular components
- add CardForm, MatchedCard, SQLPreview and TopBar components
- show placeholder match results and SQL query

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68551879f86c833282c954b302eb4ad8